### PR TITLE
update node:18-alpine to node:22-alpine and include _scripts in the d…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 
 ## Dependency Stage ##
-FROM node:18-alpine AS dep
+FROM node:22-alpine AS dep
 WORKDIR /app
 COPY package.json ./package.json
 COPY yarn.lock ./yarn.lock
+COPY _scripts ./_scripts
 # copy `dist` if it exists already
 COPY dis[t]/web ./dist/web
 # git is needed for jinter
@@ -12,7 +13,7 @@ RUN apk add git
 RUN if [ ! -d 'dist/web' ]; then yarn ci; fi
 
 ## Build Stage ##
-FROM node:18-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY . .
 COPY --from=dep /app/dis[t]/web ./dist/web


### PR DESCRIPTION
## Pull Request Type
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
closes #585

## Description
as outlined in #585, `minimatch` dependency requires node version >=22.
also, the `Dependency Stage` was missing the `_scripts` directory (required for the `postinstall` phase of `yarn ci`)

## Testing
1. git clone https://github.com/MarmadileManteater/FreeTubeAndroid
2. run `docker build -t freetubecordova .` as instructed in the README
3. verify that the image builds successfully