### PR TITLE
Migrate to targeting Android API level 35

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 
 class VersionInfo {
@@ -51,14 +52,14 @@ android {
       };
     }
     namespace = "io.freetubeapp.freetube"
-    compileSdk = 34
+    compileSdk = 35
     dataBinding {
         enable = true
     }
     defaultConfig {
         applicationId = versionInfo.appId
         minSdk = 29
-        targetSdk = 34
+        targetSdk = 35
         versionCode = versionInfo.versionCode
         versionName = versionInfo.version
 
@@ -84,8 +85,10 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
+    kotlin {
+      compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+      }
     }
     buildFeatures {
         viewBinding = true

--- a/android/app/src/main/java/io/freetubeapp/freetube/KeepAliveService.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/KeepAliveService.kt
@@ -14,7 +14,7 @@ class KeepAliveService : Service() {
     private const val CHANNEL_ID = "keep_alive"
   }
   override fun onBind(intent: Intent?): IBinder? {
-    TODO("Not yet implemented")
+    throw NotImplementedError()
   }
   override fun onCreate() {
     super.onCreate()

--- a/android/app/src/main/java/io/freetubeapp/freetube/MainActivity.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/MainActivity.kt
@@ -46,7 +46,9 @@ class MainActivity: FreeTubeActivity() {
         // Check whether the initial data is ready.
         if (!state.showSplashScreen) {
           // The content is ready. Start drawing.
-          webView.dispatchEvent("update-insets", (webView.insets / state.scale).toJSON())
+          val insets = (webView.insets / state.scale).toJSON()
+          insets.put("cornerRadius", webView.cornerRadius / state.scale)
+          webView.dispatchEvent("update-insets", insets)
           true
         } else {
           // The content isn't ready. Suspend.

--- a/android/app/src/main/java/io/freetubeapp/freetube/MainActivity.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/MainActivity.kt
@@ -2,11 +2,18 @@ package io.freetubeapp.freetube
 
 import android.content.Intent
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
+import android.view.WindowInsets
 import android.view.WindowManager
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.doOnAttach
 import io.freetubeapp.freetube.activities.FreeTubeActivity
 import io.freetubeapp.freetube.databinding.ActivityMainBinding
+import io.freetubeapp.freetube.helpers.div
 import io.freetubeapp.freetube.helpers.isDarkMode
+import io.freetubeapp.freetube.helpers.toJSON
 import io.freetubeapp.freetube.helpers.toYtUrl
 import io.freetubeapp.freetube.helpers.urlEncode
 import io.freetubeapp.freetube.javascript.dispatchEvent
@@ -21,6 +28,7 @@ class MainActivity: FreeTubeActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
+    enableEdgeToEdge()
     webView = FreeTubeWebView(this)
 
     val url = intent?.toYtUrl()
@@ -33,10 +41,12 @@ class MainActivity: FreeTubeActivity() {
 
     ActivityMainBinding.inflate(layoutInflater).apply {
       setContentView(root)
+
       root.viewTreeObserver.addOnPreDrawListener {
         // Check whether the initial data is ready.
         if (!state.showSplashScreen) {
           // The content is ready. Start drawing.
+          webView.dispatchEvent("update-insets", (webView.insets / state.scale).toJSON())
           true
         } else {
           // The content isn't ready. Suspend.
@@ -61,6 +71,9 @@ class MainActivity: FreeTubeActivity() {
     state.darkMode = newConfig.isDarkMode()
     val colorString = if (state.darkMode) { "dark" } else { "light" }
     webView.dispatchEvent("enabled-$colorString-mode")
+    webView.postDelayed({
+      webView.dispatchEvent("update-insets", (webView.insets / state.scale).toJSON())
+    }, 10)
   }
 
   /**

--- a/android/app/src/main/java/io/freetubeapp/freetube/MainActivity.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
+import android.view.ViewTreeObserver
 import android.view.WindowInsets
 import android.view.WindowManager
 import androidx.activity.enableEdgeToEdge
@@ -13,6 +14,8 @@ import io.freetubeapp.freetube.activities.FreeTubeActivity
 import io.freetubeapp.freetube.databinding.ActivityMainBinding
 import io.freetubeapp.freetube.helpers.div
 import io.freetubeapp.freetube.helpers.isDarkMode
+import io.freetubeapp.freetube.helpers.addOnPreDraw
+import io.freetubeapp.freetube.helpers.removeOnPreDraw
 import io.freetubeapp.freetube.helpers.toJSON
 import io.freetubeapp.freetube.helpers.toYtUrl
 import io.freetubeapp.freetube.helpers.urlEncode
@@ -41,14 +44,14 @@ class MainActivity: FreeTubeActivity() {
 
     ActivityMainBinding.inflate(layoutInflater).apply {
       setContentView(root)
-
-      root.viewTreeObserver.addOnPreDrawListener {
+      root.viewTreeObserver.addOnPreDraw {
         // Check whether the initial data is ready.
         if (!state.showSplashScreen) {
           // The content is ready. Start drawing.
           val insets = (webView.insets / state.scale).toJSON()
           insets.put("cornerRadius", webView.cornerRadius / state.scale)
           webView.dispatchEvent("update-insets", insets)
+          root.viewTreeObserver.removeOnPreDraw(this)
           true
         } else {
           // The content isn't ready. Suspend.

--- a/android/app/src/main/java/io/freetubeapp/freetube/activities/FreeTubeActivity.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/activities/FreeTubeActivity.kt
@@ -52,19 +52,10 @@ open class FreeTubeActivity: LaunchIntentActivity() {
     }
   }
 
-  fun themeSystemUi(navigationHex: String, statusHex: String, navigationDarkMode: Boolean,  statusDarkMode: Boolean) {
+  fun themeSystemUi(navigationDarkMode: Boolean,  statusDarkMode: Boolean) {
     runOnUiThread {
       windowInsetsControllerCompat.isAppearanceLightNavigationBars = !navigationDarkMode
       windowInsetsControllerCompat.isAppearanceLightStatusBars = !statusDarkMode
-      window.navigationBarColor = navigationHex.hexToColour()
-      window.statusBarColor = statusHex.hexToColour()
-
-      val bitmap = createBitmap(24, 24)
-      bitmap.eraseColor(navigationHex.hexToColour())
-      val canvas = Canvas(bitmap)
-      canvas.drawColor(navigationHex.hexToColour())
-      val bitmapDrawable = bitmap.toDrawable(resources)
-      window.setBackgroundDrawable(bitmapDrawable)
     }
   }
 }

--- a/android/app/src/main/java/io/freetubeapp/freetube/helpers/ApplicationState.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/helpers/ApplicationState.kt
@@ -9,5 +9,6 @@ data class ApplicationState(
   var paused: Boolean = false,
   var isInAPrompt: Boolean = false,
   var keepScreenOn: Boolean = false,
-  var currentPage: String? = null
+  var currentPage: String? = null,
+  var scale: Float = 1.0f
 )

--- a/android/app/src/main/java/io/freetubeapp/freetube/helpers/InsetsExtensions.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/helpers/InsetsExtensions.kt
@@ -1,0 +1,45 @@
+package io.freetubeapp.freetube.helpers
+
+import android.graphics.Insets
+import org.json.JSONObject
+
+fun Insets.toJSON(): JSONObject {
+  val json = JSONObject()
+  json.put("top", top)
+  json.put("bottom", bottom)
+  json.put("left", left)
+  json.put("right", right)
+
+  return json
+}
+
+operator fun Insets.div(denominator: Float): Insets {
+  return Insets.of(
+    (left / denominator).toInt(),
+    (top / denominator).toInt(),
+    (right / denominator).toInt(),
+    (bottom / denominator).toInt()
+  )
+}
+
+operator fun Insets.plus(insets: Insets): Insets {
+  return Insets.of(
+    left + insets.left,
+    top + insets.top,
+    right + insets.right,
+    bottom + insets.bottom
+  )
+}
+
+fun Insets.addSystemBars(insets: Insets): Insets {
+  return Insets.of(
+    left,
+    if (top != 0) {
+      top
+    } else {
+      insets.top
+    },
+    right,
+    bottom + insets.bottom
+  )
+}

--- a/android/app/src/main/java/io/freetubeapp/freetube/helpers/ViewTreeObserverExtensions.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/helpers/ViewTreeObserverExtensions.kt
@@ -1,0 +1,17 @@
+package io.freetubeapp.freetube.helpers
+
+import android.view.ViewTreeObserver
+
+fun ViewTreeObserver.addOnPreDraw(listener: ViewTreeObserver.OnPreDrawListener.() -> Boolean) {
+  addOnPreDrawListener (
+    object: ViewTreeObserver.OnPreDrawListener {
+      override fun onPreDraw(): Boolean {
+        return listener()
+      }
+    }
+  )
+}
+
+fun ViewTreeObserver.removeOnPreDraw(listener: ViewTreeObserver.OnPreDrawListener) {
+  removeOnPreDrawListener(listener)
+}

--- a/android/app/src/main/java/io/freetubeapp/freetube/javascript/FreeTubeJavaScriptInterface.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/javascript/FreeTubeJavaScriptInterface.kt
@@ -10,11 +10,13 @@ import io.freetubeapp.freetube.activities.FreeTubeActivity
 import io.freetubeapp.freetube.helpers.MediaSessionFacade
 import io.freetubeapp.freetube.helpers.Promise
 import io.freetubeapp.freetube.helpers.WriteMode
+import io.freetubeapp.freetube.helpers.div
 import io.freetubeapp.freetube.helpers.getDataDirectory
 import io.freetubeapp.freetube.helpers.getFileName
 import io.freetubeapp.freetube.helpers.readBytes
 import io.freetubeapp.freetube.helpers.readText
 import io.freetubeapp.freetube.helpers.resolveAmbiguousUri
+import io.freetubeapp.freetube.helpers.toJSON
 import io.freetubeapp.freetube.helpers.writeBytes
 import io.freetubeapp.freetube.webviews.FreeTubeWebView
 import kotlinx.coroutines.CoroutineScope
@@ -362,8 +364,8 @@ class FreeTubeJavaScriptInterface(
    *
    */
   @JavascriptInterface
-  fun themeSystemUi(navigationHex: String, statusHex: String, navigationDarkMode: Boolean  = true,  statusDarkMode: Boolean = true) {
-    context.themeSystemUi(navigationHex, statusHex, navigationDarkMode, statusDarkMode)
+  fun themeSystemUi(navigationDarkMode: Boolean  = true,  statusDarkMode: Boolean = true) {
+    context.themeSystemUi(navigationDarkMode, statusDarkMode)
   }
 
   @JavascriptInterface
@@ -394,7 +396,17 @@ class FreeTubeJavaScriptInterface(
 
   @JavascriptInterface
   fun setScale(scale: Int) {
+    context.state.scale = scale / 100.0f
+    if (scale == 0) {
+      context.state.scale = 1f
+    }
     webView.setScale(scale / 100.0, context)
+    webView.dispatchEvent("update-insets", (webView.insets / context.state.scale).toJSON())
+  }
+
+  @JavascriptInterface
+  fun getInsets(): String {
+    return "${(webView.insets / context.state.scale).toJSON()}"
   }
 
   // endregion

--- a/android/app/src/main/java/io/freetubeapp/freetube/webviews/FreeTubeWebView.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/webviews/FreeTubeWebView.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.graphics.Insets
 import android.os.Build
+import android.view.RoundedCorner
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
@@ -36,10 +37,21 @@ class FreeTubeWebView (
   } else {
     WindowInsetsControllerWrapper(context.windowInsetsController)
   }
+  val cornerRadius: Float
+    get() {
+      val radius = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        rootWindowInsets.getRoundedCorner(RoundedCorner.POSITION_TOP_LEFT)?.radius
+      } else {
+        null
+      } ?: 0
+
+      return radius / context.resources.displayMetrics.density
+    }
   val insets: Insets
     get() {
       val insets = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        rootWindowInsets.getInsets(WindowInsets.Type.displayCutout()).addSystemBars(rootWindowInsets.getInsets(WindowInsets.Type.systemBars()))
+        rootWindowInsets.getInsets(WindowInsets.Type.displayCutout())
+          .addSystemBars(rootWindowInsets.getInsets(WindowInsets.Type.systemBars()))
       } else {
         rootWindowInsets.systemWindowInsets
       }

--- a/android/app/src/main/java/io/freetubeapp/freetube/webviews/FreeTubeWebView.kt
+++ b/android/app/src/main/java/io/freetubeapp/freetube/webviews/FreeTubeWebView.kt
@@ -4,19 +4,26 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.graphics.Insets
 import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.WindowInsets
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.doOnAttach
 import io.freetubeapp.freetube.R
 import io.freetubeapp.freetube.activities.FreeTubeActivity
 import io.freetubeapp.freetube.helpers.WindowInsetsControllerWrapper
+import io.freetubeapp.freetube.helpers.addSystemBars
+import io.freetubeapp.freetube.helpers.div
+import io.freetubeapp.freetube.helpers.plus
 import io.freetubeapp.freetube.javascript.FreeTubeJavaScriptInterface
+import io.freetubeapp.freetube.javascript.consoleLog
 import io.freetubeapp.freetube.javascript.dispatchEvent
 import org.json.JSONObject
 
@@ -29,6 +36,15 @@ class FreeTubeWebView (
   } else {
     WindowInsetsControllerWrapper(context.windowInsetsController)
   }
+  val insets: Insets
+    get() {
+      val insets = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        rootWindowInsets.getInsets(WindowInsets.Type.displayCutout()).addSystemBars(rootWindowInsets.getInsets(WindowInsets.Type.systemBars()))
+      } else {
+        rootWindowInsets.systemWindowInsets
+      }
+      return insets / context.resources.displayMetrics.density
+    }
   val jsInterface = FreeTubeJavaScriptInterface(context, this)
 
   val onConsoleMessage: (JSONObject) -> Unit = { messageData: JSONObject ->
@@ -87,9 +103,6 @@ class FreeTubeWebView (
         if (view != null) {
           val viewGroup = (parent as ViewGroup)
 
-          // hide system ui
-          viewGroup.fitsSystemWindows = false
-
           windowInsetsControllerWrapper.hide(WindowInsetsCompat.Type.systemBars())
           windowInsetsControllerWrapper.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 
@@ -102,8 +115,6 @@ class FreeTubeWebView (
       override fun onHideCustomView() {
         val viewGroup = (parent as ViewGroup)
 
-        // show system ui
-        viewGroup.fitsSystemWindows = true
         windowInsetsControllerWrapper.show(WindowInsetsCompat.Type.systemBars())
 
         viewGroup.removeView(fullscreenView)

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.10" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jan 27 08:18:27 EST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -20,6 +20,14 @@
   margin-inline: 10px;
 }
 
+@media only screen and (width > 680px) {
+  /** this is painful */
+  .routerView.flexBox:has(.ftNotificationBanner):not(:has(.floatingRefreshSection)) {
+    top: -40px;
+    position: relative;
+  }
+}
+
 .banner {
   inline-size: 85%;
   margin-block: 40px 0;
@@ -69,6 +77,11 @@
   .routerView {
     margin-block: 20px 68px;
     margin-inline: 8px;
+  }
+
+  .routerView.flexBox {
+    padding-block-start: var(--top-inset);
+    padding-block-end: var(--bottom-inset);
   }
 
   .banner {

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -9,6 +9,7 @@
       hideLabelsSideBar: hideLabelsSideBar && !isSideNavOpen,
       noTapHighlight: !tapHighlight
     }"
+    :style="insetsStyle"
   >
     <TopNav
       :inert="isAnyPromptOpen"
@@ -109,7 +110,7 @@
 
 <script setup>
 import { marked } from 'marked'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { useI18n } from './composables/use-i18n-polyfill'
 import { useRoute, useRouter } from 'vue-router'
 
@@ -176,6 +177,8 @@ const defaultInvidiousInstance = computed(() => store.getters.getDefaultInvidiou
 
 const dataReady = ref(false)
 
+const insetsStyle = reactive({})
+
 onMounted(async () => {
   await store.dispatch('grabUserSettings')
 
@@ -207,6 +210,12 @@ onMounted(async () => {
     }
 
     if (process.env.IS_ANDROID) {
+      window.addEventListener('update-insets', ({ left, top, bottom }) => {
+        insetsStyle['--left-inset'] = `${left}px`
+        insetsStyle['--top-inset'] = `${top}px`
+        insetsStyle['--bottom-inset'] = `${bottom}px`
+      })
+
       window.addEventListener('youtube-link', ({ link }) => {
         handleYoutubeLink(link)
       })

--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -210,10 +210,15 @@ onMounted(async () => {
     }
 
     if (process.env.IS_ANDROID) {
-      window.addEventListener('update-insets', ({ left, top, bottom }) => {
+      window.addEventListener('update-insets', ({ left, top, bottom, cornerRadius }) => {
         insetsStyle['--left-inset'] = `${left}px`
         insetsStyle['--top-inset'] = `${top}px`
         insetsStyle['--bottom-inset'] = `${bottom}px`
+        if (left > 0 || top > 0) {
+          insetsStyle['--corner-radius'] = `${left}px`
+        } else {
+          insetsStyle['--corner-radius'] = `${cornerRadius}px`
+        }
       })
 
       window.addEventListener('youtube-link', ({ link }) => {

--- a/src/renderer/components/FtPrompt/FtPrompt.css
+++ b/src/renderer/components/FtPrompt/FtPrompt.css
@@ -73,11 +73,14 @@
 
 @media only screen and (width <= 420px) {
   .promptCard.fullscreen {
-    min-block-size: 100vh;
+    min-block-size: calc(100vh);
     max-block-size: 100%;
     max-inline-size: 100%;
     inline-size: 100vw;
     inset-inline-start: 0;
     overflow: initial;
+    padding-block-start: var(--top-inset);
+    padding-block-end: var(--bottom-inset);
+    box-sizing: border-box;
   }
 }

--- a/src/renderer/components/FtRefreshWidget/FtRefreshWidget.scss
+++ b/src/renderer/components/FtRefreshWidget/FtRefreshWidget.scss
@@ -3,6 +3,7 @@
 .floatingRefreshSection {
   box-sizing: border-box;
   padding-block: 5px;
+  padding-block-start: calc(var(--top-inset) + 5px);
   padding-inline: 10px;
   box-shadow: 0 2px 1px 0 var(--primary-shadow-color);
   background-color: var(--card-bg-color);

--- a/src/renderer/components/FtSearchFilters/FtSearchFilters.css
+++ b/src/renderer/components/FtSearchFilters/FtSearchFilters.css
@@ -73,7 +73,7 @@
 
 @media only screen and (width <= 420px) {
   .radioFlexBox {
-    max-block-size: calc(100vh - 8.5em);
+    max-block-size: calc(100vh - 8.5em - var(--top-inset) - var(--bottom-inset));
     margin-bottom: 0.75em;
     overflow-y: scroll;
     justify-content: start;

--- a/src/renderer/components/FtaLogViewer/FtaLogViewer.css
+++ b/src/renderer/components/FtaLogViewer/FtaLogViewer.css
@@ -4,7 +4,7 @@
 }
 
 .logs {
-  max-block-size: calc(100vh - 164px);
+  max-block-size: calc(100vh - 164px - var(--top-inset) - var(--bottom-inset));
   overflow-y: scroll;
   display: flex;
   flex-direction: column-reverse;

--- a/src/renderer/components/SideNav/SideNav.css
+++ b/src/renderer/components/SideNav/SideNav.css
@@ -1,11 +1,11 @@
 .sideNav {
   display: block;
-  block-size: calc(100vh - 60px);
+  block-size: calc(100vh - 60px - var(--top-inset));
   inline-size: 200px;
   overflow-x: hidden;
   position: sticky;
   inset-inline-start: 0;
-  inset-block-start: 60px;
+  inset-block-start: calc(60px + var(--top-inset));
   z-index: 3;
   box-shadow: 1px -1px 1px -1px var(--primary-shadow-color);
   background-color: var(--side-nav-color);
@@ -13,6 +13,7 @@
   transition-duration: 150ms;
   transition-timing-function: ease-in-out;
   user-select: none;
+  padding-inline-start: var(--left-inset);
 }
 
 .inner {
@@ -220,6 +221,7 @@
     inset-inline-start: 0;
     inset-block-end: 0;
     display: flex;
+    padding-block-end: var(--bottom-inset);
   }
 
   .topNavOption {

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.css
@@ -30,6 +30,7 @@
   inline-size: 70px;
   z-index: 0;
   box-shadow: 3px -3px 5px 0 rgb(0 0 0 / 20%);
+  bottom: calc(var(--bottom-inset) + 60px);
 }
 
 @media only screen and (width <= 680px) {

--- a/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
+++ b/src/renderer/components/SideNavMoreOptions/SideNavMoreOptions.vue
@@ -162,61 +162,6 @@
         </p>
       </router-link>
     </div>
-    <router-link
-      class="navOption mobileShow"
-      :title="$t('History.History')"
-      :aria-label="hideLabelsSideBar ? $t('History.History'): null"
-      to="/history"
-    >
-      <FontAwesomeIcon
-        :icon="['fas', 'history']"
-        class="navIcon"
-        :class="applyNavIconExpand"
-      />
-      <p
-        id="historyNavLabel"
-        class="navLabel"
-      >
-        {{ $t("History.History") }}
-      </p>
-    </router-link>
-    <hr>
-    <router-link
-      class="navOption mobileShow"
-      :title="$t('Settings.Settings')"
-      :aria-label="hideLabelsSideBar ? $t('Settings.Settings') : null"
-      to="/settings"
-    >
-      <FontAwesomeIcon
-        :icon="['fas', 'sliders-h']"
-        class="navIcon"
-        :class="applyNavIconExpand"
-      />
-      <p
-        id="settingsNavLabel"
-        class="navLabel"
-      >
-        {{ $t("Settings.Settings") }}
-      </p>
-    </router-link>
-    <router-link
-      class="navOption mobileHidden"
-      :title="$t('About.About')"
-      to="/about"
-      :aria-label="hideLabelsSideBar ? $t('About.About') : null"
-    >
-      <FontAwesomeIcon
-        :icon="['fas', 'info-circle']"
-        class="navIcon"
-        :class="applyNavIconExpand"
-      />
-      <p
-        v-if="!hideLabelsSideBar"
-        class="navLabel"
-      >
-        {{ $t("About.About") }}
-      </p>
-    </router-link>
   </div>
 </template>
 

--- a/src/renderer/components/TopNav/TopNav.scss
+++ b/src/renderer/components/TopNav/TopNav.scss
@@ -8,6 +8,7 @@
 }
 
 .topNav {
+  padding-block-start: var(--top-inset);
   align-content: center;
   align-items: center;
   background-color: var(--card-bg-color);
@@ -209,6 +210,7 @@
     display: flex;
 
     @media only screen and (width <= 680px) {
+      margin-block-start: var(--top-inset);
       background-color: var(--side-nav-color);
       inset-inline: 0;
       position: fixed;

--- a/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
+++ b/src/renderer/components/ft-shaka-video-player/ft-shaka-video-player.css
@@ -187,6 +187,8 @@
 
   /* copied from .shaka-scrim-container */
   transition: opacity cubic-bezier(0.4, 0, 0.6, 1) 0.6s;
+  margin-block-start: var(--top-inset);
+  margin-inline-start: var(--corner-radius);
 }
 
 :deep(.playerFullscreenTitleOverlay:dir(rtl)) {

--- a/src/renderer/helpers/android/system.js
+++ b/src/renderer/helpers/android/system.js
@@ -8,9 +8,7 @@ export function updateAndroidTheme(usesMain = false) {
   const bodyStyle = getComputedStyle(document.body)
   const isDark = isColourDark(bodyStyle.getPropertyValue('--primary-text-color'))
   const isDarkTop = usesMain ? isColourDark(bodyStyle.getPropertyValue('--text-with-main-color')) : isDark
-  const top = !usesMain ? bodyStyle.getPropertyValue('--card-bg-color') : bodyStyle.getPropertyValue('--primary-color')
-  const bottom = bodyStyle.getPropertyValue('--side-nav-color')
-  android.themeSystemUi(bottom, top, isDark, isDarkTop)
+  android.themeSystemUi(isDark, isDarkTop)
 }
 
 export function getConsoleLogs() {

--- a/src/renderer/scss-partials/_utils.scss
+++ b/src/renderer/scss-partials/_utils.scss
@@ -20,16 +20,16 @@
   position: fixed;
   inset-block-start: 60px;
   inset-inline-end: 0;
-  inline-size: calc(100% - 80px);
+  inline-size: calc(100% - 80px - var(--left-inset));
   margin-inline: 0;
   z-index: 3;
 
   @include is-side-nav-open {
-    inline-size: calc(100% - 200px);
+    inline-size: calc(100% - 200px - var(--left-inset));
   }
 
   @include are-side-bar-labels-hidden {
-    inline-size: calc(100% - 60px);
+    inline-size: calc(100% - 60px - var(--left-inset));
   }
 
   @media only screen and (width <= 680px) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->
<!-- Do not create PR's with AI! (PRs created mainly with AI will be closed. They waste our team's time. We ban repeat offenders.) -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other
- [X] Chore

## Related issue
Addresses #684

## Description
This PR upgrades the API compile target from 34 to 35. The most important change between those two is that drawing your app "edge-to-edge" is now the default. To compensate for this, it seems that it is pretty easy to actually pull the window insets now (jetpack compose does this by default). It deprecated changing the color of the system nav directly, so now, the webview has to have the padding inside itself. A benefit of this is that it simplifies the system UI theming code.

- The main WebView is now `edge-to-edge`
  - The system nav remains the same color as the rest of the UI even when inside of a prompt
  - The side nav is padded to dodge the display cutout
- Screen curvature and cutouts are now taken into account when a video is fullscreen

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
|before|after|
|--|--|
|<img width="784" height="350" alt="Screenshot-2026-04-16_15:40:28" src="https://github.com/user-attachments/assets/94a7fcad-5306-4ff2-ad98-fb50fee72ee0" />|<img width="784" height="350" alt="Screenshot-2026-04-16_15:40:28" src="https://github.com/user-attachments/assets/187eef2d-60da-4ae8-a839-19187b7ea22e" />|

|before|after|
|--|--|
|<img width="784" height="350" alt="Screenshot-2026-04-16_15:40:28" src="https://github.com/user-attachments/assets/b13abcb4-77b5-4b39-9f54-8cc062ce6c5c" />|<img width="784" height="350" alt="Screenshot-2026-04-16_15:40:28" src="https://github.com/user-attachments/assets/cd8e3434-bcab-46ea-a74e-218effe7fc69" />|

|before|after|
|--|--|
|<img alt="Screenshot-2026-04-16_15:39:19" src="https://github.com/user-attachments/assets/81fd7927-c5f6-495c-bf1b-57594c8833d8" />|<img alt="Screenshot-2026-04-16_15:39:19" src="https://github.com/user-attachments/assets/8d270d87-348b-4c6c-b697-8101836767f5" />|

|before|after|
|--|--|
|<img alt="Screenshot-2026-04-16_16:04:35" src="https://github.com/user-attachments/assets/0e5b0aba-6006-4234-957e-e7351f6bf195" />|<img alt="Screenshot-2026-04-16_16:04:35" src="https://github.com/user-attachments/assets/60b5951f-f339-4ece-808d-14e3f6425694" />|



|before|after|
|--|--|
|<img alt="Screenshot-2026-04-16_15:39:19" src="https://github.com/user-attachments/assets/a64e697e-ae72-47e2-b161-283e1d7deac4" />|<img alt="Screenshot-2026-04-16_15:39:19" src="https://github.com/user-attachments/assets/f54cb54f-2a7e-4153-89ae-cdf758abb45c" />|


## Testing
<!-- How can reviewers verify that the PR produces correct results? -->
<!-- Please provide instructions so that others can ensure that your pull request would produce correct results. For examples see, https://github.com/FreeTubeApp/FreeTube/pull/5743, https://github.com/FreeTubeApp/FreeTube/pull/7349, https://github.com/FreeTubeApp/FreeTube/pull/5125, https://github.com/FreeTubeApp/FreeTube/pull/7338 -->
*general app ui*
1. Ensure the edges of the app aren't overlapped by the system UI 
2. Open a prompt (add to video to playlist works)
3. Ensure the edges of the app still aren't overlapped by the system UI

*popups*
1. Open a video
2. Tap the share button
3. Ensure the system UI is darkened with the rest of the app

*fullscreen video title*
1. Open a video
4. Fullscreen it
5. See if the video title dodges the cutout and curvature of the screen
6. Rotate the display to all possible orientations

*display cutout on landscape*
1. Rotate the display
2. Ensure the sidenav is padded appropriately